### PR TITLE
Update for owncloud version seven

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ wherever you are, when you need it.
 This appliance includes all the standard features in `TurnKey Core`_,
 and on top of that:
 
-- ownCloud configurations:
+- ownCloud Community Edition:
    
    - Installed from ownCloud debian repository to /var/www/owncloud
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,13 @@
+turnkey-owncloud-13.1 (1) turnkey; urgency=low
+
+  * ownCloud:
+
+    - Dynamically added trusted domains to config.php on firstboot.
+    - Upgraded to the latest version, currently 7.x.
+    - Revised readme.rst to emphasize this is ownCloud Community Edition.
+
+ -- John Carver <dude4linux@gmail.com>  Fri, Sep 12 2014 21:05:35 +0000
+
 turnkey-owncloud-13.0 (1) turnkey; urgency=low
 
   * ownCloud:

--- a/conf.d/main
+++ b/conf.d/main
@@ -34,6 +34,10 @@ curl $REPO/Release.key | apt-key add -
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get --force-yes --assume-yes install owncloud
 
+# patch owncloud document download.php - This patch may be removed after the next update of owncloud
+# add namespace to constant #347 - https://github.com/owncloud/documents/pull/347
+sed -i 's/!==Filter_Office/ !== \\OCA\\Documents\\Filter\\Office/' /var/www/owncloud/apps/documents/ajax/download.php
+
 # tweak footer
 TEMPLATE=$WEBROOT/core/templates/layout.guest.php
 sed -i "s|<footer>.*|<footer><p class='info' style='width: auto \!important;'><a href='http://www.turnkeylinux.org/owncloud'>ownCloud Appliance</a> \&ndash; Powered by <a href='http://www.turnkeylinux.org'>TurnKey Linux</a></p></footer>|" $TEMPLATE

--- a/overlay/etc/cron.d/owncloud
+++ b/overlay/etc/cron.d/owncloud
@@ -1,0 +1,2 @@
+# run cron.php for owncloud
+5-59/15 * * * * www-data 	/usr/bin/php -f /var/www/owncloud/cron.php /dev/null 2>&1

--- a/overlay/usr/lib/inithooks/firstboot.d/40owncloud
+++ b/overlay/usr/lib/inithooks/firstboot.d/40owncloud
@@ -4,5 +4,25 @@
 . /etc/default/inithooks
 
 [ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
+
+config="/var/www/owncloud/config/config.php"
+
+trusted_domains="//  Trusted Domains\n"
+
+if [[ $APP_FQDN ]]; then
+	trusted_domains+="    $((n++)) => '$APP_FQDN',\n"
+	trusted_domains+="    $((n++)) => '${APP_FQDN%%.*}',\n"
+fi
+
+trusted_domains+="    $((n++)) => '$(hostname)',\n"
+
+[[ $APP_IP ]] && trusted_domains+="    $((n++)) => '$APP_IP',\n"
+
+trusted_domains+="    $((n++)) => 'localhost',\n"
+trusted_domains+="    $((n++)) => '127.0.0.1'"
+
+sed -i "/127.0.0.1/c \
+$trusted_domains" $config
+
 $INITHOOKS_PATH/bin/owncloud.py --pass="$APP_PASS"
 

--- a/overlay/usr/lib/inithooks/firstboot.d/40owncloud
+++ b/overlay/usr/lib/inithooks/firstboot.d/40owncloud
@@ -14,11 +14,14 @@ if [[ $APP_FQDN ]]; then
 	trusted_domains+="    $((n++)) => '${APP_FQDN%%.*}',\n"
 fi
 
-trusted_domains+="    $((n++)) => '$(hostname)',\n"
+if [[ "$(hostname)" != "${APP_FQDN%%.*}" ]]; then
+	trusted_domains+="    $((n++)) => '$(hostname)',\n"
+fi
+
+trusted_domains+="    $((n++)) => 'localhost',\n"
 
 [[ $APP_IP ]] && trusted_domains+="    $((n++)) => '$APP_IP',\n"
 
-trusted_domains+="    $((n++)) => 'localhost',\n"
 trusted_domains+="    $((n++)) => '127.0.0.1'"
 
 sed -i "/127.0.0.1/c \

--- a/plan/main
+++ b/plan/main
@@ -1,6 +1,11 @@
 #include <turnkey/base>
 #include <turnkey/lamp>
 
+libreoffice-writer
+ghostscript
+ffmpeg
+imagemagick
+php5-imagick
 php5-gd
 php5-cli
 php5-curl


### PR DESCRIPTION
These changes dynamically update the config.php file, adding the list of 'trusted domains' (actually host headers used to access the ownCloud server).  The changes work with both version 6.x and the newly released 7.0 version of ownCloud.  The updates rely on the separate pull request create-ssl-cert-with-subject-alternative-names-SAN.