### PR TITLE
Preparation for owncloud 8

### DIFF
--- a/overlay/usr/lib/inithooks/bin/owncloud.py
+++ b/overlay/usr/lib/inithooks/bin/owncloud.py
@@ -43,6 +43,9 @@ def main():
             "ownCloud Password",
             "Enter new password for the ownCloud 'admin' account.")
 
+    # make sure MySQL is running when we call the OCServer hasher in owncloud_pass.php
+    m = MySQL()
+
     command = ["php", join(dirname(__file__), 'owncloud_pass.php'), password]
     p = subprocess.Popen(command, stdin=PIPE, stdout=PIPE, shell=False)
     stdout, stderr = p.communicate()
@@ -51,8 +54,9 @@ def main():
 
     cryptpass = stdout.strip()
 
-    m = MySQL()
     m.execute('UPDATE owncloud.users SET password=\"%s\" WHERE uid=\"admin\";' % cryptpass)
+    m.execute('UPDATE owncloud.preferences SET configvalue = 1 where userid = \"admin\" and appid = \"firstrunwizard\" and configkey = \"show\"')
+    m.execute('DELETE FROM owncloud.preferences where userid = \"admin\" and appid = \"login\" and configkey = \"lastLogin\"')
 
 
 if __name__ == "__main__":

--- a/overlay/usr/lib/inithooks/bin/owncloud_pass.php
+++ b/overlay/usr/lib/inithooks/bin/owncloud_pass.php
@@ -1,15 +1,11 @@
 <?php
 
-include '/var/www/owncloud/config/config.php';
-include '/var/www/owncloud/3rdparty/phpass/PasswordHash.php';
+use Symfony\Component\Console\Application;
+
+require_once '/var/www/owncloud/lib/base.php';
 
 if(count($argv)!=2) die("usage: $argv[0] password\n");
 
-$password = $argv[1];
-$salt = $CONFIG['passwordsalt'];
-
-$PasswordHash = new PasswordHash(8, false);
-print $PasswordHash->HashPassword($password.$salt);
+print \OC::$server->getHasher()->hash($argv[1]);
 
 ?>
-

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-owncloud-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-owncloud-secrets
@@ -8,7 +8,12 @@ CONF=/var/www/owncloud/config/config.php
 SALT=$(mcookie)
 sed -i "s|passwordsalt.*|passwordsalt\' => '$SALT',|" $CONF
 
+INSTANCEID=$(mcookie | cut -b -13)
+sed -i "s|instanceid.*|instanceid\' => '$INSTANCEID',|" $CONF
+
 PASSWORD=$(mcookie)
 sed -i "s|dbpassword.*|dbpassword\' => '$PASSWORD',|" $CONF
 $INITHOOKS_PATH/bin/mysqlconf.py --user=owncloud --pass="$PASSWORD"
 
+SECRET=$(mcookie)$(mcookie)
+sed -i "s|secret.*|secret\' => '$SECRET',|" $CONF


### PR DESCRIPTION
This series contains the necessary changes to make Turnkey work with owncloud8.
It also resets the admin login stats which makes it possible to "sysprep" a freshly installed owncloud server again.
The new owncloud_pass.php script is only tested with owncloud 7 and 8.