### PR TITLE
Fixes to owncloud appliance

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,17 @@
+turnkey-owncloud-14.1 (1) turnkey; urgency=low
+
+  * ownCloud:
+
+    - Fixed inithooks config of domain to ensure it gets replaced properly
+      when reconfiguring
+
+    - Added dependencies for external storage and ldap users apps
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jonathan Struebel <jonathan.struebel@gmail.com>  Wed, 13 Jan 2016 20:55:31 -0700
+
 turnkey-owncloud-14.0 (1) turnkey; urgency=low
 
   * ownCloud:

--- a/overlay/usr/lib/inithooks/bin/owncloud.py
+++ b/overlay/usr/lib/inithooks/bin/owncloud.py
@@ -76,6 +76,7 @@ def main():
     '1' => '%s',
     """
 
+    call(['sed', '-i', "/^'1' => /d", '/usr/share/owncloud/config/config.php'])
     call(['sed', '-i', sedcom % domain, '/usr/share/owncloud/config/config.php'])
 
     m.execute('UPDATE owncloud.users SET password=\"%s\" WHERE uid=\"admin\";' % cryptpass)

--- a/plan/main
+++ b/plan/main
@@ -8,6 +8,12 @@ php5-json
 php-xml-parser
 php-pear
 
+php-aws-sdk
+php-dropbox
+php-google-api-php-client
+smbclient
+php5-ldap
+
 bzip2
 
 owncloud


### PR DESCRIPTION
I needed to use owncloud for a project this weekend and found a bug and an improvement so I added them to the appliance.

The bug is fixed in the last commit, when running it as a container it would have two domains configured because of the preseeded init. The preseeded init value took precedence since it ended up later in the file. The fix deletes any existing domains that were configured by the init before inserting the current one.

The improvement is to install the dependencies required by the external files and user ldap apps. I went to enable them and got a white screen since they were missing. With them installed by default that won't happen. Even though these apps are not enabled by default, as a user I wouldn't expect dependencies of the installed apps to be missing.

Please let me know if I need to correct anything.